### PR TITLE
Fix for media filter. I used the screenSize.get function but it had been removed.

### DIFF
--- a/match-media.js
+++ b/match-media.js
@@ -123,6 +123,9 @@
         }
       }
     };
+    
+    // Return the actual size (it's string name defined in the rules)
+    this.get = getCurrentMatch;
 
     this.is = function (list) {
       list = assureList(list);


### PR DESCRIPTION
TypeError: screenSize.get is not a function
    at mediaFilter (http://localhost:17382/components/angular-media-queries/match-media.js:198:29)

Fixed by setting this.get = getCurrentMatch allowing filter to use screenSize.get function.