### PR TITLE
Inconsistent Method Signature for onChange()

### DIFF
--- a/match-media.js
+++ b/match-media.js
@@ -154,7 +154,7 @@
     // Executes the callback function ONLY when the match differs from previous match.
     // Returns the current match truthiness.
     // The 'scope' parameter is required for cleanup reasons (destroy event).
-    this.onChange = function (scope, list, callback) {
+    this.onChange = function (list, callback, scope) {
       var currentMatch = getCurrentMatch();
       list = assureList(list);
       if (!scope) {


### PR DESCRIPTION
In all methods except ```onChange()```, the scope parameter is always the last parameter. Ever the documentation is having the last parameter of ```onChange()``` as scope. We need to change it to make it consistent.